### PR TITLE
Make default IME configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ to normal mode.
 Plug 'simnalamburt/vim-tiny-ime', { 'do' : './build' }
 ```
 
+## Options
+
+If you want to change the default IME, set `g:tiny_ime_default`.
+
+```vim
+let g:tiny_ime_default = 'Colemak'
+```
+
+The default value of `g:tiny_ime_default` is `'ABC'`.
+
 <br>
 
 --------

--- a/plugin/tiny-ime.vim
+++ b/plugin/tiny-ime.vim
@@ -4,6 +4,10 @@ if exists('g:loaded_tiny_ime')
 endif
 let g:loaded_tiny_ime = 1
 
+if !exists('g:tiny_ime_default')
+  let g:tiny_ime_default = 'ABC'
+endif
+
 " Verify that the build is complete
 let s:tiny_ime_dir = expand('<sfile>:p:h:h')
 if !executable(s:tiny_ime_dir.'/set-ime')
@@ -17,5 +21,5 @@ endif
 " Register 'set-ime' to the autocommands
 augroup tiny_ime
   autocmd!
-  autocmd InsertLeave * silent! execute '!'.s:tiny_ime_dir.'/set-ime ABC'
+  autocmd InsertLeave * silent! execute '!'.s:tiny_ime_dir.'/set-ime '.g:tiny_ime_default
 augroup END

--- a/plugin/tiny-ime.vim
+++ b/plugin/tiny-ime.vim
@@ -15,4 +15,7 @@ if !executable(s:tiny_ime_dir.'/set-ime')
 endif
 
 " Register 'set-ime' to the autocommands
-autocmd InsertLeave * silent! execute '!'.s:tiny_ime_dir.'/set-ime ABC'
+augroup tiny_ime
+  autocmd!
+  autocmd InsertLeave * silent! execute '!'.s:tiny_ime_dir.'/set-ime ABC'
+augroup END

--- a/plugin/tiny-ime.vim
+++ b/plugin/tiny-ime.vim
@@ -5,14 +5,14 @@ endif
 let g:loaded_tiny_ime = 1
 
 " Verify that the build is complete
-let tiny_ime_dir = expand('<sfile>:p:h:h')
-if findfile('set-ime', tiny_ime_dir) == ""
+let s:tiny_ime_dir = expand('<sfile>:p:h:h')
+if !executable(s:tiny_ime_dir.'/set-ime')
   echo 'vim-tiny-ime: You have to run the following command to complete install of vim-tiny-ime.'
   echo ' '
-  echo '    $ '.tiny_ime_dir.'/build'
+  echo '    $ '.s:tiny_ime_dir.'/build'
   echo ' '
   finish
 endif
 
 " Register 'set-ime' to the autocommands
-autocmd InsertLeave * silent! execute "!".tiny_ime_dir."/set-ime ABC"
+autocmd InsertLeave * silent! execute '!'.s:tiny_ime_dir.'/set-ime ABC'


### PR DESCRIPTION
Other commits do:
- Make `tiny_ime_dir` variable to script-local
- Check if `set-ime` is executable
- Use augroup to avoid duplication of autocmd